### PR TITLE
Adds an option to select Fortnite role for users

### DIFF
--- a/crates/interactions/commands/repl.json
+++ b/crates/interactions/commands/repl.json
@@ -11,6 +11,10 @@
         {
           "name": "Streamer",
           "value": "646518404030922772"
+        },
+        {
+          "name": "Fortnite Player",
+          "value": "906236413694079006"
         }
       ]
     }


### PR DESCRIPTION
Spawned from `#community-gardening` from Ryan Warner. See conversation here: https://discord.com/channels/601625579166367755/739302315877728272/906231659630841858

I think us extending the functionality for role is a good thing here. In the future when the codenames discord bot is ready, I was considering this technique to allow for us to ping folks who are normally interested as well. I think it is a good way to get folks aware.
